### PR TITLE
Make SimpleSituation heading and content able to be functions.

### DIFF
--- a/games/media/js/undum.js
+++ b/games/media/js/undum.js
@@ -155,9 +155,9 @@
     SimpleSituation.prototype.enter = function(character, system, from) {
         if (this.heading) {
             if ($.isFunction(this.heading)) {
-                system.write(this.heading());
+                system.writeHeading(this.heading());
             } else {
-                system.write(this.heading);
+                system.writeHeading(this.heading);
             }
         }
         if (this.content) {


### PR DESCRIPTION
It would be nice for heading and content to be (optionally) callable. This simple change allows advanced javascripters to make use of fancy things like templating engines and more advanced DOM retrieval (like in `tutorial.gam.en.js:338`) while still enjoying the conveniences of the SimpleSituation.

I'm using [$.isFunction()](http://api.jquery.com/jQuery.isFunction/), since it's available, instead of the try/catch I see you using elsewhere. Not sure which is superior.
