### PR TITLE
afterEnter hook and once-link bug fix

### DIFF
--- a/games/media/js/undum.js
+++ b/games/media/js/undum.js
@@ -840,13 +840,7 @@
      */
     var doWrite = function(content, selector, addMethod, appendMethod) {
         continueOutputTransaction();
-        var output;
-        if( typeof content == 'function' ) {
-            output = augmentLinks(content());
-        }
-        else {
-            output = augmentLinks(content);
-        }
+        var output = augmentLinks(content);
         var element;
         if (selector) element = $(selector);
         if (!element) {
@@ -1026,7 +1020,7 @@
 
     /* This gets called when a link needs to be followed, regardless
      * of whether it was user action that initiated it. */
-    var linkRe = /^([-a-zA-Z0-9]+|\.)(\/([-0-9a-zA-Z]+))?$/;
+    var linkRe = /^([-a-z0-9]+|\.)(\/([-0-9a-z]+))?$/;
     var processLink = function(code) {
         // Check if we should do this now, or if processing is already
         // underway.


### PR DESCRIPTION
Hi,

There's a minor bug with once links: if you have a once link with the same href in the next situation the story will disable it as well when you click on the link in the previous situation. I changed the order of `processClick()` and `system.clearLinks()` which seems to have fixed it and I haven't noticed any side effects yet.

I also added a global hook called `afterEnter` that runs after entering a new situation and after the situation's text has been displayed. `enter` runs before displaying the text, and this was too early for my needs.

(Sorry about the many commits, they amount up to only those two changes. I couldn't find a way to send a pull request for only some commits.)
