### PR TITLE
Exposing interactivity state

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -1093,6 +1093,12 @@ games will not load correctly. A player may save their game at one
 point and find most of their progress wiped out when they load it
 again.
 
+If your game has elements that should not be triggered while Undum is
+replaying a saved game, for example sound effects or popup notifications,
+you can use `undum.isInteractive()` to test whether the game is being
+played normally (returns `true`) or being loaded from a save game
+(returns `false`).
+
 
 # Translation and Internationalization
 

--- a/games/media/js/undum.js
+++ b/games/media/js/undum.js
@@ -1313,6 +1313,8 @@
         QualityGroup: QualityGroup,
 
         game: game,
+        
+        isInteractive: function() { return interactive; },
 
         // The undum set of translated strings.
         language: {}


### PR DESCRIPTION
I've added an `isInteractive()` function that can be used to test whether the game is being played normally or a saved game being replayed. This is useful when the game has elements that shouldn't be repeated when the game is being loaded, like sound effects (they would all play simultaneously), alerts/dialogs, or if the player is prompted for text input during the game.
