### PR TITLE
doClick and localization default

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -576,6 +576,16 @@ Carries out the action associated with the given URL, as if it had
 been the `href` of a HTML link that the user clicked. This allows you
 to procedurally change situation and carry out actions from your code.
 
+#### `doClick(URL)`
+
+Carries out an action just like `doLink`, but the click is saved
+to the turn sequence so that the action will be replayed when loading
+the game. `doClick` should be used only as a direct response to an
+event, for example the player clicking on a button in the user
+interface. `doLink` should be used instead when the action is a 
+continuation of another action initiated by clicking on a normal link 
+to avoid the action being executed twice when loading the game.
+
 #### `rnd`
 
 This holds a general purpose random number generator. It is an object

--- a/games/media/js/undum.js
+++ b/games/media/js/undum.js
@@ -441,6 +441,14 @@
     System.prototype.doLink = function(code) {
         processLink(code);
     };
+    
+    /* The same as doLink(), but the link is saved to the progress sequence 
+     * so it will be "re-clicked" when the game is loaded. This should
+     * be used when the action is coming from an outside event like a timer
+     * or clicking on a button in the user interface. */
+    System.prototype.doClick = function(code) {
+        processClick(code);
+    };
 
     /* Turns any links that target the given href into plain
      * text. This can be used to remove action options when an action


### PR DESCRIPTION
Here's the wrapper for `processClick()`. It's hard to explain the difference between that and doLink, so feel free to improve what I scribbled in the documentation.

Also, there was an issue where the script would halt if the HTML document didn't have the `lang` attribute, so I made it default to `en` if nothing else is specified.
