### PR TITLE
Fixes for localStorage detection and handling

### DIFF
--- a/games/media/js/undum.js
+++ b/games/media/js/undum.js
@@ -40,7 +40,15 @@
     // Feature detection
 
     var hasLocalStorage = function() {
-        return ('localStorage' in window) && window.localStorage !== null;
+        var hasStorage = false;
+        try {
+            hasStorage = ('localStorage' in window) && window.localStorage !== null && window.localStorage !== undefined;
+        }
+        catch (err) {
+            // Firefox with the "Always Ask" cookie accept setting will throw an error when attempting to access localStorage
+            hasStorage = false;
+        }
+        return hasStorage;
     };
 
     var isMobileDevice = function() {
@@ -1323,7 +1331,7 @@
     /* Set up the game when everything is loaded. */
     $(function() {
         // Handle storage.
-        if (hasLocalStorage) {
+        if (hasLocalStorage()) {
             var erase = $("#erase").click(function() {
                 doErase();
             });
@@ -1344,7 +1352,7 @@
                 startGame();
             }
         } else {
-            $("#buttons").html("<p>"+"no_local_storage".l()+"</p>");
+            $(".buttons").html("<p>"+"no_local_storage".l()+"</p>");
             startGame();
         }
 


### PR DESCRIPTION
- When checking for localStorage, hasLocalStorage is called as a function, not tested as a variable. (Fixes browsers always thinking localStorage is available.)
- Save/load button display is selected as a CSS class, not an ID. (Fixes localStorage always looking available.)
- hasLocalStorage() checks for window.localStorage === undefined as well as null. (Fixes detection on IE8 and probably others.)
- hasLocalStorage() wraps detection in a try-catch block. (Fixes detection in Firefox when "Accept Cookies" is set to "Always Ask", which throws an exception on accessing localStorage.)
