### PR TITLE
Added "data-exit" to HTML loader

### DIFF
--- a/games/media/js/undum.js
+++ b/games/media/js/undum.js
@@ -1263,6 +1263,7 @@
                 displayOrder: parse($situation.attr("data-display-order")),
                 tags: parseList($situation.attr("data-tags"), false),
                 // Simple Situation content.
+		exit: parseFn($situation.attr("data-exit")),
                 heading: $situation.attr("data-heading"),
                 choices: parseList($situation.attr("data-choices"), true),
                 minChoices: parse($situation.attr("data-min-choices")),


### PR DESCRIPTION
As simple as it sounds : allows to define an exit function from the HTML code.
