### PR TITLE
Undum option: repeatable actions

### DIFF
--- a/games/media/js/undum.js
+++ b/games/media/js/undum.js
@@ -563,6 +563,9 @@
      */
     var System = function() {
         this.rnd = null;
+        this.options = {
+          repeatable_links: true
+        }
         this.time = 0;
     };
 
@@ -1636,8 +1639,9 @@
 
                         // If we're a once-click, remove all matching
                         // links.
-                        if (a.hasClass("once")) {
-                            system.clearLinks(href);
+                        if (system.options.repeatable_links == false
+                          || (system.options.repeatable_links == true && a.hasClass("once"))) {
+                          system.clearLinks(href);
                         }
 
                         processClick(href);


### PR DESCRIPTION
A repeatable action is an action which can be called more than once.

But what if a game has no repeatable actions? Every link in the game still has to bear "once" class.
So I've implemented a switch for Undum. Just call:

```
system.options.repeatable_links = false
```

in your `undum.game.init` function and get rid of all "once" classes! It completely turns off repeatable actions.

I don't think the option name is really the best choice but I definitely need this feature.
