### PR TITLE
Call SimpleSituation.enter before main content

### DIFF
--- a/games/media/js/undum.js
+++ b/games/media/js/undum.js
@@ -310,6 +310,7 @@
                 system.writeHeading(this.heading);
             }
         }
+        if (this._enter) this._enter(character, system, from);
         if (this.content) {
             if ($.isFunction(this.content)) {
                 system.write(this.content());
@@ -323,7 +324,6 @@
                                                        this.maxChoices);
             system.writeChoices(choices);
         }
-        if (this._enter) this._enter(character, system, from);
     };
     SimpleSituation.prototype.act = function(character, system, action) {
         var response = this.actions[action];


### PR DESCRIPTION
The `enter` function is called after the whole situation is already written. I think this is wrong, and here's why.

Any text after the implicit choice menu obliges user to read the choices, then read the text, then scroll up to choose an action. So `enter` should be called before writing implicit choices.

The next bit may be an author preference and I think we can make an option for that but still. The `enter` function has a `from` parameter. It's a great place to look at character qualities, look where he came from and write a response. 

I think the dynamic response after the static one is mostly a Western tradition after Inform and parser games. But isn't it more convenient to read the reaction to your actions first and then skip through the static paragraph? So the **how** player got there goes before **what** he sees. And the enter function can return this "how" by analysing `from` parameter.
