### PR TITLE
Issue #27: alternate link syntax

### DIFF
--- a/games/media/games/tutorial/tutorial.game.en.js
+++ b/games/media/games/tutorial/tutorial.game.en.js
@@ -54,7 +54,7 @@ undum.game.situations = {
     todo: new undum.SimpleSituation(
         "<p>Two things can happen in a situation. The character either\
         <a href='links'>leaves</a> the situation and enters another one, or\
-        they carry out some <a href='./do-something'>action</a>. Actions may\
+        they carry out some <a href='./do-something?once'>action</a>. Actions may\
         perform some processing, they may display some results, but\
         ultimately they put the character back into the same situation\
         again.</p>\

--- a/games/media/js/undum.js
+++ b/games/media/js/undum.js
@@ -1478,7 +1478,7 @@
 
     /* This gets called when a link needs to be followed, regardless
      * of whether it was user action that initiated it. */
-    var linkRe = /^([-a-z0-9]+|\.)(\/([-0-9a-z]+))?$/;
+    var linkRe = /^([-a-z0-9]+|\.)(\/([-0-9a-z]+))?(\?.+)?$/;
     var processLink = function(code) {
         // Check if we should do this now, or if processing is already
         // underway.
@@ -1586,7 +1586,8 @@
             //  Remove links and transient sections.
             $('#content a').each(function(index, element) {
                 var a = $(element);
-                if (a.hasClass('sticky') || a.attr("href").match(/[?&]sticky[=&]?)/) return;
+                if (a.hasClass('sticky') || a.attr("href").match(/[?&]sticky[=&]?/))
+                    return;
                 a.replaceWith($("<span>").addClass("ex_link").html(a.html()));
             });
             var contentToHide = $('#content .transient, #content ul.options');
@@ -1639,7 +1640,7 @@
 
                         // If we're a once-click, remove all matching
                         // links.
-                        if (a.hasClass("once") || href.match(/[?&]once[=&]?/) {
+                        if (a.hasClass("once") || href.match(/[?&]once[=&]?/)) {
                             system.clearLinks(href);
                         }
 


### PR DESCRIPTION
I've implemented it using regular expressions: http://regexr.com/398me

It doesn't need to be fool-proof (and not that we'd include something like "onceover" as a different parameter class). Also works for `transient` class. I've changed link regexp not to slap the `raw` class on them.
