### PR TITLE
Add new variants of System.prototype.write()

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -97,6 +97,22 @@ or if a selector is given, inserted before the matching element. On
 browsers that support it, the story will be scrolled to the insertion
 point.
 
+#### `writeInto(content, elementSelector)`
+
+Writes content into the element matched by `elementSelector`. When
+used without specifying a selector, this method is identical to
+`write`. When a selector is supplied, the content is written as an
+additional child node of the matched element, instead of as a new
+node just after that element, as is the case with `write`.
+
+#### `replaceWith(content, elementSelector)`
+
+Replaces an element with `content`. If `elementSelector` isn't
+supplied, this will replace the entire situation with the given
+`content`. If it is, the matched element will be replaced, including
+the matched set of tags; `content` slides in place of the matched
+element in the DOM.
+
 #### `writeChoices(listOfSituationIds)`
 
 *Since version 2*

--- a/games/media/js/undum.js
+++ b/games/media/js/undum.js
@@ -623,6 +623,33 @@
         doWrite(content, elementSelector, 'prepend', 'before');
     };
 
+    /* Outputs regular content to the page. The content supplied must
+     * be valid "Display Content".
+     *
+     * When a selector is not specified, this behaves identically to
+     * System.prototype.write. If you supply a selector, the content
+     * appears as a child node at the end of the content of the
+     * element that matches that selector.
+     */
+
+    System.prototype.writeInto = function(content, elementSelector) {
+        doWrite(content, elementSelector, 'append', 'append');
+    };
+
+    /* Replaces content with the content supplied, which must be valid
+     * "Display Content".
+     *
+     * When a selector is not specified, this replaces the entire
+     * content of the page. Otherwise, it replaces the element matched
+     * with the selector. This replaces the entire element, including
+     * the matched tags, so ideally the content supplied should fit
+     * in its place in the DOM with the same kind of display element.
+     */
+
+    System.prototype.replaceWith = function(content, elementSelector) {
+        doWrite(content, elementSelector, 'replaceWith', 'replaceWith');
+    };
+
     /* Carries out the given situation change or action, as if it were
      * in a link that has been clicked. This allows you to do
      * procedural transitions. You might have an action that builds up


### PR DESCRIPTION
Those two helper functions are variants of System.prototype.write, different only in that they pass different sets of JQuery function names to `doWrite()`. I found myself wanting ways of replacing content wholesale or adding nodes into an element in a way that was square with everything `doWrite()` does, so this is the easiest way to get that working in a modular way.

`System.prototype.writeInto()` calls `doWrite()` passing the name of the JQuery `append()` function. This means that unlike `System.prototype.write()`, when a selector is specified, new content is written as a new child node at the end of the matched element, rather than as a new sibling node after the matched element.

`System.prototype.replaceWith()` calls `doWrite()` passing the name of the JQuery `replaceWith()` function. The result is that either the matched element, or the entire situation is replaced with the given content. I wrote this to use it exclusively *with* a selector, and I'm not sure the latter is safe; maybe this should throw an error if it's called without a selector, or instead it should default to selecting the first/last child node of the situation?