### PR TITLE
Change handling of scrolling after doWrite()

### DIFF
--- a/games/media/js/undum.js
+++ b/games/media/js/undum.js
@@ -1344,7 +1344,13 @@
         }
         if (scrollPoint > output.offset().top)
             scrollPoint = output.offset().top;
-        scrollStack[scrollStack.length-1] = scrollPoint;
+        /* We add a fifth of the window height to this point, so that the
+         * element won't be placed too close to the bottom edge of the
+         * viewport. If we overshoot the viewport, we'll just go down to
+         * the bottom - desirable behaviour anyway, especially if we are
+         * already there. */
+        scrollStack[scrollStack.length-1] =
+            (scrollPoint + ($(window).height() * 0.2));
     };
 
     /* Gets the unique id used to identify saved games. */


### PR DESCRIPTION
The current behaviour for scrolling towards a recently written element in Undum can create presentation issues when a newly-created element (inserted into the DOM by `doWrite()`) is positioned very close to the top edge of its next sibling; in those instances, Undum has a tendency to scroll the viewport up such that the element is up against the viewport's bottom edge. This small change adds about 20% of the viewport's height to the point Undum moves the scroll to. This behaviour is especially nicer in situations when, for instance, content is written into an inline DOM element that's short enough that the next element is in the same line.
