### PR TITLE
Fix bug with augmentLinks() not working properly when doWrite inserts an a element

### DIFF
--- a/games/media/js/undum.js
+++ b/games/media/js/undum.js
@@ -1657,7 +1657,7 @@
         var output = $(content);
 
         // Wire up the links for regular <a> tags.
-        output.find("a").each(function(index, element) {
+        output.find("a").addBack("a").each(function(index, element) {
             var a = $(element);
             var href = a.attr('href');
             if (!a.hasClass("raw")|| href.match(/[?&]raw[=&]?/)) {


### PR DESCRIPTION
I noticed this issue while working on a project: I had set up a system (part of a miniature helper library) to automate generating "cycling links" similar to the popular Twine extension, and found that they weren't working. After tracking down the bug, I found why: If `doWrite()` is called to insert an `a` element, `augmentLinks` doesn't work. The culprit turned out to be `$.find`; it only traverses the _children_ of the matched elements. So for instance, if you pass the following html to `doWrite()`:

``` html
<a id="outer" href="./outer">
Link <a id="inner" href="./inner">Text</a>
</a>
```

Only `#inner` will be augmented correctly, because when `$.find()` is called on this block of html it returns only that element. Fixing this issue is simple: We compose `$.find()` with `$.addBack()`, which goes back one step of JQuery's DOM traversal stack, filters it (In this case once again looking for a elements), and adds them back into the chain. This means that top-level elements are also matched and correctly augmented; so if you want to insert a whole pile of inline anchors and spans nested and interspersed, you can:

``` html
<a>
  <span>
    <a class="inner">
      stuff
    </a>
  </span>
</a>
<span>
  and things
</span>
<span>
  and
  <a>
    more
  </a>
</span>
```

...will have all of its anchors, and only them, correctly matched and augmented inside `augmentLinks()`.
