### PR TITLE
Fixed 'null' in WordScaleQuality lists not behaving as you'd expect

### DIFF
--- a/games/media/js/undum.js
+++ b/games/media/js/undum.js
@@ -476,7 +476,8 @@
             val = this.values.length - 1;
         }
         if (!this.useBonuses) mod = "";
-        return this.values[val] + mod;
+        if (this.values[val] === null) return null;
+        return this.values[val] + mod; // Type coercion
     };
 
     /* A specialization of WordScaleQuality that uses the FUDGE RPG's


### PR DESCRIPTION
One of the features of `QualityDefinition` is that if the `format()` method returns `null`, nothing at all is written and the quality isn't displayed at all. You would expect that if one of the items in a `WordScaleQuality` is `null`, then that quality shouldn't be displayed at all as long as the quality is at that point in the scale; this is useful, for instance, for a quality that should only display if it is greater than some quantity (Eg, tracking wounds the player character suffered), a quality that depletes until it disappears entirely (Eg, tracking how much of a finite resource the player character has left), or a quality that is only visible if it is exceptional (Eg, in a game with many stats, showing only stats that aren't average).

Unfortunately, Undum currently doesn't behave this way. The reason why is line 479 in undum.js:

```JavaScript
  return this.values[val] + mod;
```

Because mod is always a string, this line type coerces  `this.values[val]` into a string, so that `null` becomes `'null'`. I've added a line to check for `null` here and return an actual `null` value if that's the case, thus making it so the expected behaviour actually happens, making the interface here more consistent with the other QualityDefinition variants.