### PR TITLE
Fix bad reference to `this` inside closure

### DIFF
--- a/games/media/js/undum.js
+++ b/games/media/js/undum.js
@@ -1619,8 +1619,9 @@
                 a.replaceWith($("<span>").addClass("ex_link").html(a.html()));
             });
             var contentToHide = $('#content .transient, #content ul.options');
+            var that = this;
             contentToHide.add($("#content a").filter(function(){
-                return this.attr("href").match(/[?&]transient[=&]?/);
+                return that.attr("href").match(/[?&]transient[=&]?/);
             }));
             if (interactive) {
                 if (mobile) {


### PR DESCRIPTION
I was receiving an error when using sticky links, and tracked it to this bad usage of `this` inside a closure. Saving a reference to `this` outside the closure and using that variable fixes the issue. Thanks, Javascript.