### PR TITLE
Fix bad reference to this (for real)

### DIFF
--- a/games/media/js/undum.js
+++ b/games/media/js/undum.js
@@ -1619,9 +1619,8 @@
                 a.replaceWith($("<span>").addClass("ex_link").html(a.html()));
             });
             var contentToHide = $('#content .transient, #content ul.options');
-            var that = this;
             contentToHide.add($("#content a").filter(function(){
-                return that.attr("href").match(/[?&]transient[=&]?/);
+                return $(this).attr("href").match(/[?&]transient[=&]?/);
             }));
             if (interactive) {
                 if (mobile) {


### PR DESCRIPTION
So, my previous fix was misunderstanding the situation. Inside a `filter()` lambda, `this` is bound to the current DOM object. In order to call `attr()` on it, we first need to wrap it in a jQuery object. This PR corrects my earlier mistake. Sorry about that!