### PR TITLE
Use https jquery so JS works on https github pages

### DIFF
--- a/docs/out/index.html
+++ b/docs/out/index.html
@@ -102,7 +102,7 @@
            alt="Pro captu lectoris habent sua fata libelli.">
     </div>
     <script type="text/javascript"
-     src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.4/jquery.min.js">
+     src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.4/jquery.min.js">
     </script>
     <script type="text/javascript">
     (function() {


### PR DESCRIPTION
https://idmillington.github.io/undum/ refuses to run its jquery script, because it's loading non-https jquery. Using https jquery will fix the https version of the website, allowing the content to resize itself to fit the screen.